### PR TITLE
Refine auth UI handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 
   <div id="calendar"></div>
 
-  <footer>Version: v1.4.0</footer>
+  <footer>Version: v1.4.1</footer>
 
   <!-- Firebase (modular) -->
   <script type="module">

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <button id="btnSignup">Sign Up</button>
     <button id="btnLogin">Log In</button>
     <button id="btnGoogle">Sign in with Google</button>
-    <button id="btnLogout">Log Out</button>
+    <button id="btnLogout" class="hidden">Log Out</button>
   </div>
   <div id="who" class="hidden"></div>
 
@@ -130,7 +130,7 @@
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     const $ = id => document.getElementById(id);
-    const status = $('status'), who = $('who'), authBox = $('auth'), formBox = $('form');
+    const status = $('status'), who = $('who'), formBox = $('form');
 
     function toast(msg, ok=true){
       status.textContent = msg;
@@ -311,14 +311,17 @@
     $('btnLogout').onclick = ()=> signOut(auth);
 
     onAuthStateChanged(auth, async (user)=>{
+      const loginIds = ['email','pass','btnSignup','btnLogin','btnGoogle'];
       if(user){
         who.textContent = `Welcome, ${user.email || ''}`;
         who.classList.remove('hidden');
-        authBox.classList.add('hidden');
+        loginIds.forEach(id=>$(id).classList.add('hidden'));
+        $('btnLogout').classList.remove('hidden');
         await loadEvents();
       }else{
         who.classList.add('hidden');
-        authBox.classList.remove('hidden');
+        loginIds.forEach(id=>$(id).classList.remove('hidden'));
+        $('btnLogout').classList.add('hidden');
         calendar && calendar.removeAllEvents();
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "calendar",
+  "version": "1.4.0",
+  "scripts": {
+    "build": "node set-version.js",
+    "test": "echo 'No tests'"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "build": "node set-version.js",
     "test": "echo 'No tests'"

--- a/set-version.js
+++ b/set-version.js
@@ -1,5 +1,16 @@
 const fs = require('fs');
-const pkg = require('./package.json');
+
+const pkgPath = './package.json';
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+function bumpPatch(version) {
+  const parts = version.split('.').map(Number);
+  parts[2] = (parts[2] || 0) + 1;
+  return parts.join('.');
+}
+
+pkg.version = bumpPatch(pkg.version);
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 
 const file = 'index.html';
 const version = `Version: v${pkg.version}`;

--- a/set-version.js
+++ b/set-version.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const pkg = require('./package.json');
+
+const file = 'index.html';
+const version = `Version: v${pkg.version}`;
+let html = fs.readFileSync(file, 'utf8');
+html = html.replace(/Version: v[0-9.]+/, version);
+fs.writeFileSync(file, html);
+console.log(`Updated ${file} to ${version}`);


### PR DESCRIPTION
## Summary
- Hide Log Out button by default using `hidden` class
- Toggle visibility of auth elements individually instead of hiding the container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb1db4ac8322adc3ea622c8f6e9d